### PR TITLE
Fix code scanning alert no. 17: Incomplete string escaping or encoding

### DIFF
--- a/public/frontend/assets/vendor/datatables/jquery.dataTables.js
+++ b/public/frontend/assets/vendor/datatables/jquery.dataTables.js
@@ -4503,7 +4503,7 @@
 					word = m ? m[1] : word;
 				}
 	
-				return word.replace('"', '');
+				return word.replace(/"/g, '');
 			} );
 	
 			search = '^(?=.*?'+a.join( ')(?=.*?' )+').*$';


### PR DESCRIPTION
Fixes [https://github.com/fhappyk/student/security/code-scanning/17](https://github.com/fhappyk/student/security/code-scanning/17)

To fix the problem, we need to ensure that all occurrences of the double-quote character are replaced in the string `word`. This can be achieved by using a regular expression with the global flag (`g`). Specifically, we should replace `word.replace('"', '')` with `word.replace(/"/g, '')`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
